### PR TITLE
Don't enforce public access on uploaded files

### DIFF
--- a/config/schema_plugins/iso19139/update-fixed-info.xsl
+++ b/config/schema_plugins/iso19139/update-fixed-info.xsl
@@ -204,7 +204,7 @@
 				<gmd:URL>
 					<xsl:choose>
 						<xsl:when test="/root/env/system/downloadservice/simple='true'">
-							<xsl:value-of select="concat($serviceUrl,'resources.get?uuid=',/root/env/uuid,'&amp;fname=',$fname,'&amp;access=public')"/>
+							<xsl:value-of select="concat($serviceUrl,'resources.get?uuid=',/root/env/uuid,'&amp;fname=',$fname,'&amp;access=private')"/>
 						</xsl:when>
 						<xsl:when test="/root/env/system/downloadservice/withdisclaimer='true'">
 							<xsl:value-of select="concat($serviceUrl,'file.disclaimer?uuid=',/root/env/uuid,'&amp;fname=',$fname,'&amp;access=public')"/>


### PR DESCRIPTION
This reverts https://github.com/geonetwork/core-geonetwork/commit/c33d2fc6dc08b65090214110e1963221d822578d#diff-1a0a7bc96168e03d2bd8b32895099ecf
See https://github.com/geonetwork/core-geonetwork/issues/1015

Even if this isn't merged upstream yet (see discussion in https://github.com/geonetwork/core-geonetwork/pull/1318) we should ensure that people starting playing with gn3 inside georchestra don't end up with files publicly accessible.
